### PR TITLE
Moved session from cookie to DB sessions table, fixed cookie overflow…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,9 @@ gem 'omniauth-auth0', '~> 2.2'
 # Gem to prevent forged authentiation requests
 gem 'omniauth-rails_csrf_protection', '~> 0.1'
 
+# Gem to prevent cookie size issue
+gem 'activerecord-session_store'
+
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,12 @@ GEM
     activerecord (6.0.3.3)
       activemodel (= 6.0.3.3)
       activesupport (= 6.0.3.3)
+    activerecord-session_store (1.1.3)
+      actionpack (>= 4.0)
+      activerecord (>= 4.0)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0)
     activestorage (6.0.3.3)
       actionpack (= 6.0.3.3)
       activejob (= 6.0.3.3)
@@ -214,6 +220,7 @@ PLATFORMS
   x64-mingw32
 
 DEPENDENCIES
+  activerecord-session_store
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)

--- a/app/assets/stylesheets/login.scss
+++ b/app/assets/stylesheets/login.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the login controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/concerns/session_cleared.rb
+++ b/app/controllers/concerns/session_cleared.rb
@@ -1,0 +1,14 @@
+# app/controllers/concerns/session_cleared
+
+module SessionCleared
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :clear_session
+  end
+
+  def clear_session
+    reset_session
+    puts "CLEARED THE SESSION APPARENTLY"
+  end
+end

--- a/app/helpers/login_helper.rb
+++ b/app/helpers/login_helper.rb
@@ -1,0 +1,2 @@
+module LoginHelper
+end

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -15,4 +15,3 @@
 <h4>About this System</h4>
 <p>This system is a point tracker for BMES.</p>
 <p>Login to view your stats.</p>
-<%= button_to 'Login', 'auth/auth0', method: :post %>

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,1 @@
+Rails.application.config.session_store :active_record_store, :key => '_my_app_sessions_key'

--- a/db/migrate/20200923025121_add_sessions_table.rb
+++ b/db/migrate/20200923025121_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration[6.0]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, :null => false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, :unique => true
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_22_224949) do
+ActiveRecord::Schema.define(version: 2020_09_23_025121) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,6 +71,15 @@ ActiveRecord::Schema.define(version: 2020_09_22_224949) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_members_on_email", unique: true
+  end
+
+  create_table "sessions", force: :cascade do |t|
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
+    t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
   add_foreign_key "accomplishments_members", "accomplishments"

--- a/test/controllers/login_controller_test.rb
+++ b/test/controllers/login_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class LoginControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
I fixed an issue where the client-side cookie value was causing errors. The new system stores session variables in the DB in a sessions table instead of in cookies. A bundle install, and a rails db:migrate will be required to use the system. You will also need to restart the server. 