### PR TITLE
Fix manual points

### DIFF
--- a/db/migrate/20200917144211_create_manual_points.rb
+++ b/db/migrate/20200917144211_create_manual_points.rb
@@ -1,6 +1,7 @@
 class CreateManualPoints < ActiveRecord::Migration[6.0]
   def change
     create_table :manual_points do |t|
+      t.belongs_to :member, foreign_key: true
       t.decimal "points", :default => 0
       t.text "reason"
       t.timestamps

--- a/db/migrate/20200922151737_make_member_email_required.rb
+++ b/db/migrate/20200922151737_make_member_email_required.rb
@@ -1,5 +1,9 @@
 class MakeMemberEmailRequired < ActiveRecord::Migration[6.0]
-  def change
+  def up
     change_column :members, :email, :text, :unique => true, :null => false
+  end
+
+  def down
+    change_column :members, :email, :text, :unique => true
   end
 end

--- a/db/migrate/20200923004230_add_member_id_to_manual_points.rb
+++ b/db/migrate/20200923004230_add_member_id_to_manual_points.rb
@@ -1,5 +1,0 @@
-class AddMemberIdToManualPoints < ActiveRecord::Migration[6.0]
-  def change
-    add_reference :manual_points, :member, foreign_key: true
-  end
-end

--- a/db/migrate/20200923012332_change_received_to_semester.rb
+++ b/db/migrate/20200923012332_change_received_to_semester.rb
@@ -1,6 +1,11 @@
 class ChangeReceivedToSemester < ActiveRecord::Migration[6.0]
-  def change
+  def up
     remove_column :accomplishments_members, :received
     add_reference :accomplishments_members, :semester, :foreign_key => true
+  end
+
+  def down
+    remove_reference :accomplishments_members, :semester
+    add_column :accomplishments_members, :received, :datetime
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -59,11 +59,11 @@ ActiveRecord::Schema.define(version: 2020_09_23_025121) do
   end
 
   create_table "manual_points", force: :cascade do |t|
+    t.bigint "member_id"
     t.decimal "points", default: "0.0"
     t.text "reason"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "member_id"
     t.index ["member_id"], name: "index_manual_points_on_member_id"
   end
 
@@ -82,7 +82,7 @@ ActiveRecord::Schema.define(version: 2020_09_23_025121) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
-  
+
   create_table "sessions", force: :cascade do |t|
     t.string "session_id", null: false
     t.text "data"


### PR DESCRIPTION
This is a major change to the way migrations work. Our `manual-points` was misconfigured initially and the migration introduced to fix it *did not work*. I only recently noticed this change, but it should have few conflicts.

You will quite possibly have to run:
`rails db:rollback STEP=20`
`rails db:migrate`
In order to use these changes.