### PR TITLE
Add navigation tests

### DIFF
--- a/spec/features/application_integration_spec.rb
+++ b/spec/features/application_integration_spec.rb
@@ -7,4 +7,65 @@ describe '/' do
     visit '/'
     expect(page).to have_content 'Welcome'
   end
+
+  it 'has a log in button' do
+    visit '/'
+    expect(page).to have_content 'Log In'
+  end
+end
+
+describe 'navigation' do
+  before :each do
+    @member = Member.create(name: 'Test Member',
+      email: 'test_member@mail.com',
+      class_year: '1970',
+      role: 'member',
+      uid: 'BAAB00')
+    get :home, params: nil, session: {userinfo: {present: true}, app_user: {name: @member.name, email: @member.email, uid: @member.uid, kicked_out: false}} # Fake userinfo for Secured concern
+  end
+
+  it 'has a dashboard button' do
+    visit '/'
+    expect(page).to have_link 'Dashboard'
+  end
+
+  it 'redirects to /dashboard when the dashboard button is clicked' do
+    visit '/'
+    click_link 'Dashboard'
+    expect(page).to have_current_path '/dashboard'
+  end
+
+  it 'has a profile button' do
+    visit '/'
+    expect(page).to have_link 'Profile'
+  end
+
+  it 'redirects to /profile when the dashboard profile is clicked' do
+    visit '/'
+    click_link 'Profile'
+    expect(page).to have_current_path '/profile'
+  end
+
+  it 'has an Upcoming Events button' do
+    visit '/'
+    expect(page).to have_link 'Upcoming Events'
+  end
+
+  it 'redirects to /upcoming_events when the Upcoming Events button is clicked' do
+    visit '/'
+    click_link 'Upcoming Events'
+    expect(page).to have_current_path '/upcoming_events'
+  end
+
+  it 'has a log out button' do
+    visit '/'
+    expect(page).to have_link 'Log Out'
+  end
+
+  it 'logs the user out when the log out button is clicked' do
+    visit '/'
+    click_link 'Log Out'
+    expect(page).to have_current_path '/'
+    expect(page).to have_content 'You have been logged out.'
+  end
 end


### PR DESCRIPTION
I have written some navigation tests and tried to use `get` to set the session variable but this is not permitted using `rspec`. This may be a way to test with Auth0 but I'll be honest, I don't really understand: https://stackoverflow.com/questions/39229594/test-auth0-login-with-rspec-in-rails