### PR TITLE
Change events to have start_time and pt_id

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,6 +8,8 @@ class EventsController < ApplicationController
 
   helper_method :sort_column, :search_params
 
+  # filter is set up in controllers/concerns/filterable and are handled by scopes in Event
+  # sorting is set up in application_helper
   def index
     @events = if params[:search].present?
                 Event.filter(filter_params).order(sort_column)
@@ -73,11 +75,11 @@ class EventsController < ApplicationController
   private
 
   def event_params
-    params.require(:event).permit(:name, :date, :time, :event_type, :hidden, :attendance_points)
+    params.require(:event).permit(:name, :start_time, :event_type, :hidden, :attendance_points, :participation_tracker_id)
   end
 
   def filter_params
-    params[:search].slice(:name, :date, :time, :event_type, :hidden, :attendance_points)
+    params[:search].slice(:name, :start_time, :event_type, :hidden, :attendance_points, :participation_tracker_id)
   end
 
   # old way
@@ -86,7 +88,7 @@ class EventsController < ApplicationController
   end
 
   def sort_column
-    default = 'date desc'
+    default = 'start_time desc'
     if params.key?('sort') && params.key?('direction')
       # prevent injection into .order
       order = params[:sort].uniq.zip(params[:direction]).select { |s, d| Event.column_names.include?(s) and %w[asc desc].include?(d) }

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -5,12 +5,8 @@ module EventsHelper
     params[:search][:name] if params[:search].present?
   end
 
-  def date_from_search_params
-    params[:search][:date] if params[:search].present?
-  end
-
-  def time_from_search_params
-    params[:search][:time] if params[:search].present?
+  def start_time_from_search_params
+    params[:search][:start_time] if params[:search].present?
   end
 
   def hidden_from_search_params
@@ -23,5 +19,9 @@ module EventsHelper
 
   def attendance_points_from_search_params
     params[:search][:attendance_points] if params[:search].present?
+  end
+
+  def participation_tracker_id_from_search_params
+    params[:search][:participation_tracker_id] if params[:search].present?
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -5,18 +5,18 @@ class Event < ApplicationRecord
 
   has_and_belongs_to_many :members
   validates :name, presence: true
-  validates :date, presence: true
-  validates :time, presence: true
+  validates :start_time, presence: true
   validates :event_type, presence: true
   validates :attendance_points, numericality: true, presence: true
+  validates :participation_tracker_id, numericality: true
   enum event_type: { general: 0, mentorship: 10, socials: 20 }
 
   scope :filter_by_name, ->(name) { where('lower(name) LIKE :name', name: "%#{name.downcase}%") }
-  scope :filter_by_date, ->(date) { where(date: date) }
-  scope :filter_by_time, ->(time) { where(time: time) }
+  scope :filter_by_start_time, ->(start_time) { where(start_time: start_time.all_day) }
   scope :filter_by_hidden, ->(hidden) { where(hidden: hidden) }
   scope :filter_by_event_type, ->(event_type) { where(event_type: event_type) }
   scope :filter_by_attendance_points, ->(attendance_points) { where(attendance_points: attendance_points) }
+  scope :filter_by_participation_tracker_id, ->(participation_tracker_id) { where(participation_tracker_id: participation_tracker_id) }
 
   # for future use with date ranges
   def str_to_date_range(date)

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -1,10 +1,10 @@
 <tr>
   <td><%= event.name %></td>
-  <td><%= event.date %></td>
-  <td><%= event.time.strftime("%H:%M:%S") %></td>
+  <td><%= event.start_time %></td>
   <td><%= event.event_type %></td>
   <td><%= event.hidden %></td>
   <td><%= event.attendance_points %></td>
+  <td><%= event.participation_tracker_id %></td>
   <td>
   <%= link_to("", event_path(event), :class => 'fa fa-info-circle fa-lg') %>
   </td>

--- a/app/views/events/_filter_events_form.html.erb
+++ b/app/views/events/_filter_events_form.html.erb
@@ -6,11 +6,7 @@
   </td>
   <!-- TODO make this a range -->
   <td>
-    <%= f.date_field :date, value: date_from_search_params, include_blank: true %>
-  </td>
-  <!-- TODO make this a range -->
-  <td>
-    <%= f.time_field :time, value: time_from_search_params, include_blank: true %>
+    <%= f.datetime_field :start_time, value: start_time_from_search_params, include_blank: true %>
   </td>
   <td>
     <%= f.select(:event_type, 
@@ -26,9 +22,12 @@
   <td>
     <%= f.number_field :attendance_points, step: 0.01, value: attendance_points_from_search_params %>
   </td>
+  <td>
+    <%= f.number_field :participation_tracker_id, step: 1, value: participation_tracker_id_from_search_params %>
+  </td>
 
   <td>
-    <%= f.submit "Search", class: 'btn btn-success' %>
+    <%= f.submit "Search", class: 'btn btn-primary' %>
   </td>
   
 <% end %>

--- a/app/views/events/_postpone.html.erb
+++ b/app/views/events/_postpone.html.erb
@@ -6,8 +6,7 @@
   <%= form_for(@event, :url => event_path(@event), :method => 'patch') do |f| %>
     <table class=table summary="Event details">
       <tr>
-        <td><%= f.date_field(:date, min: @event.date) %></td>
-        <td><%= f.time_field(:time) %></td>
+        <td><%= f.datetime_field(:start_time, min: @event.start_time) %></td>
       </tr>
     </table>
     <div class="form-buttons">

--- a/app/views/events/delete.html.erb
+++ b/app/views/events/delete.html.erb
@@ -13,12 +13,8 @@
       <td><%= @event.name %></td>
     </tr>
     <tr>
-      <th>Date</th>
-      <td><%= @event.date %></td>
-    </tr>
-    <tr>
-      <th>Time</th>
-      <td><%= @event.time.strftime("%H:%M:%S") %></td>
+      <th>Start Time</th>
+      <td><%= @event.start_time %></td>
     </tr>
     <tr>
       <th>Type</th>
@@ -27,6 +23,10 @@
     <tr>
       <th>Attendance Points</th>
       <td><%= @event.attendance_points %></td>
+    </tr>
+    <tr>
+      <th>Participation Tracker Id</th>
+      <td><%= @event.participation_tracker_id %></td>
     </tr>
     <tr>
       <th>Created at</th>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -16,12 +16,8 @@
         <td><%= f.text_field(:name) %></td>
       </tr>
       <tr>
-        <th>Date</th>
-        <td><%= f.date_select(:date) %></td>
-      </tr>
-      <tr>
-        <th>Time</th>
-        <td><%= f.time_select(:time) %></td>
+        <th>Start Time</th>
+        <td><%= f.datetime_field(:start_time) %></td>
       </tr>
       <tr>
         <th>Type</th>
@@ -35,6 +31,10 @@
       <tr>
         <th>Attendance Points</th>
         <td><%= f.number_field(:attendance_points, in: 0.0..1000.0, step: 0.001) %></td>
+      </tr>
+      <tr>
+        <th>Participation Tracker Id</th>
+        <td><%= f.number_field(:participation_tracker_id, step: 1) %></td>
       </tr>
     </table>
 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -12,11 +12,11 @@
 <table class="table" summary="Events list">
   <tr class="header">
     <th><%= sortable "name", "Name" %></th>
-    <th><%= sortable "date", "Date" %></th>
-    <th><%= sortable "time", "Time" %></th>
+    <th><%= sortable "start_time", "Start Time" %></th>
     <th><%= sortable "event_type", "Type" %></th>
     <th><%= sortable "hidden", "Hidden?" %></th>
     <th><%= sortable "attendance_points", "Attendance Points" %></th>
+    <th><%= sortable "participation_tracker_id", "Participation Tracker Id" %></th>
     <th>Details</th>
     <th>Edit</th>
     <th>Postpone</th>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -14,12 +14,8 @@
         <td><%= f.text_field(:name) %></td>
       </tr>
       <tr>
-        <th>Date</th>
-        <td><%= f.date_select(:date) %></td>
-      </tr>
-      <tr>
-        <th>Time</th>
-        <td><%= f.time_select(:time) %></td>
+        <th>Start Time</th>
+        <td><%= f.datetime_field(:start_time) %></td>
       </tr>
       <tr>
         <th>Event Type</th>
@@ -33,6 +29,10 @@
       <tr>
         <th>Attendance Points</th>
         <td><%= f.number_field(:attendance_points, in: 0.0..1000.0, step: 0.001) %></td>
+      </tr>
+      <tr>
+        <th>Participation Tracker Id</th>
+        <td><%= f.number_field(:participation_tracker_id, step: 1) %></td>
       </tr>
     </table>
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -13,12 +13,8 @@
       <td><%= @event.name %></td>
     </tr>
     <tr>
-      <th>Date</th>
-      <td><%= @event.date %></td>
-    </tr>
-    <tr>
-      <th>Time</th>
-      <td><%= @event.time.strftime("%H:%M:%S") %></td>
+      <th>Start Time</th>
+      <td><%= @event.start_time %></td>
     </tr>
     <tr>
       <th>Type</th>
@@ -27,6 +23,10 @@
     <tr>
       <th>Attendance Points</th>
       <td><%= @event.attendance_points %></td>
+    </tr>
+    <tr>
+      <th>Participation Tracker Id</th>
+      <td><%= @event.participation_tracker_id %></td>
     </tr>
     <tr>
       <th>Created at</th>

--- a/db/migrate/20201103193240_add_event_pt_id.rb
+++ b/db/migrate/20201103193240_add_event_pt_id.rb
@@ -1,0 +1,5 @@
+class AddEventPtId < ActiveRecord::Migration[6.0]
+  def change
+    add_column :events, :participation_tracker_id, :bigint, :null => true
+  end
+end

--- a/db/migrate/20201103193937_change_event_start_time.rb
+++ b/db/migrate/20201103193937_change_event_start_time.rb
@@ -1,0 +1,26 @@
+class ChangeEventStartTime < ActiveRecord::Migration[6.0]
+  def up
+    add_column :events, :start_time, :datetime
+
+    Event.all.each do |event|
+      event.update start_time: event.time.change(year: event.date.year, month: event.date.month, day: event.date.day).to_datetime
+    end
+
+    change_column :events, :start_time, :datetime, null: false
+
+    remove_column :events, :date
+    remove_column :events, :time
+  end
+
+  def down
+    # puts ":down"
+    add_column :events, :date, :date
+    add_column :events, :time, :time
+
+    Event.all.each do |event|
+      event.update date: event.start_time.to_date, time: event.start_time.to_time
+    end
+
+    remove_column :events, :start_time, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,93 +10,94 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_201_019_215_651) do
+ActiveRecord::Schema.define(version: 2020_11_03_193937) do
+
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'accomplishments', force: :cascade do |t|
-    t.text 'name'
-    t.text 'description'
-    t.decimal 'points', default: '0.0'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.boolean 'is_dues'
+  create_table "accomplishments", force: :cascade do |t|
+    t.text "name"
+    t.text "description"
+    t.decimal "points", default: "0.0"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.boolean "is_dues"
   end
 
-  create_table 'accomplishments_members', force: :cascade do |t|
-    t.bigint 'accomplishment_id'
-    t.bigint 'member_id'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.bigint 'semester_id'
-    t.index ['accomplishment_id'], name: 'index_accomplishments_members_on_accomplishment_id'
-    t.index ['member_id'], name: 'index_accomplishments_members_on_member_id'
-    t.index ['semester_id'], name: 'index_accomplishments_members_on_semester_id'
+  create_table "accomplishments_members", force: :cascade do |t|
+    t.bigint "accomplishment_id"
+    t.bigint "member_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "semester_id"
+    t.index ["accomplishment_id"], name: "index_accomplishments_members_on_accomplishment_id"
+    t.index ["member_id"], name: "index_accomplishments_members_on_member_id"
+    t.index ["semester_id"], name: "index_accomplishments_members_on_semester_id"
   end
 
-  create_table 'events', force: :cascade do |t|
-    t.text 'name'
-    t.date 'date', null: false
-    t.time 'time'
-    t.decimal 'attendance_points', default: '0.0'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.integer 'event_type'
-    t.boolean 'hidden'
+  create_table "events", force: :cascade do |t|
+    t.text "name"
+    t.decimal "attendance_points", default: "0.0"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "event_type"
+    t.boolean "hidden"
+    t.bigint "participation_tracker_id"
+    t.datetime "start_time", null: false
   end
 
-  create_table 'events_members', id: false, force: :cascade do |t|
-    t.bigint 'member_id'
-    t.bigint 'event_id'
-    t.index ['event_id'], name: 'index_events_members_on_event_id'
-    t.index ['member_id'], name: 'index_events_members_on_member_id'
+  create_table "events_members", id: false, force: :cascade do |t|
+    t.bigint "member_id"
+    t.bigint "event_id"
+    t.index ["event_id"], name: "index_events_members_on_event_id"
+    t.index ["member_id"], name: "index_events_members_on_member_id"
   end
 
-  create_table 'manual_points', force: :cascade do |t|
-    t.bigint 'member_id'
-    t.decimal 'points', default: '0.0'
-    t.text 'reason_message'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.integer 'reason'
-    t.bigint 'semester_id'
-    t.index ['member_id'], name: 'index_manual_points_on_member_id'
-    t.index ['semester_id'], name: 'index_manual_points_on_semester_id'
+  create_table "manual_points", force: :cascade do |t|
+    t.bigint "member_id"
+    t.decimal "points", default: "0.0"
+    t.text "reason_message"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "reason"
+    t.bigint "semester_id"
+    t.index ["member_id"], name: "index_manual_points_on_member_id"
+    t.index ["semester_id"], name: "index_manual_points_on_semester_id"
   end
 
-  create_table 'members', force: :cascade do |t|
-    t.text 'name'
-    t.text 'email', null: false
-    t.integer 'class_year'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.integer 'role'
-    t.text 'uid', null: false
-    t.index ['email'], name: 'index_members_on_email', unique: true
-    t.index ['uid'], name: 'index_members_on_uid', unique: true
+  create_table "members", force: :cascade do |t|
+    t.text "name"
+    t.text "email", null: false
+    t.integer "class_year"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "role"
+    t.text "uid", null: false
+    t.index ["email"], name: "index_members_on_email", unique: true
+    t.index ["uid"], name: "index_members_on_uid", unique: true
   end
 
-  create_table 'semesters', force: :cascade do |t|
-    t.text 'name'
-    t.daterange 'dates', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
+  create_table "semesters", force: :cascade do |t|
+    t.text "name"
+    t.daterange "dates", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table 'sessions', force: :cascade do |t|
-    t.string 'session_id', null: false
-    t.text 'data'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['session_id'], name: 'index_sessions_on_session_id', unique: true
-    t.index ['updated_at'], name: 'index_sessions_on_updated_at'
+  create_table "sessions", force: :cascade do |t|
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
+    t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
-  add_foreign_key 'accomplishments_members', 'accomplishments'
-  add_foreign_key 'accomplishments_members', 'members'
-  add_foreign_key 'accomplishments_members', 'semesters'
-  add_foreign_key 'events_members', 'events'
-  add_foreign_key 'events_members', 'members'
-  add_foreign_key 'manual_points', 'members'
-  add_foreign_key 'manual_points', 'semesters'
+  add_foreign_key "accomplishments_members", "accomplishments"
+  add_foreign_key "accomplishments_members", "members"
+  add_foreign_key "accomplishments_members", "semesters"
+  add_foreign_key "events_members", "events"
+  add_foreign_key "events_members", "members"
+  add_foreign_key "manual_points", "members"
+  add_foreign_key "manual_points", "semesters"
 end


### PR DESCRIPTION
@dvansteen and @timaeus321 have been working the most on Events, so I want an approval from one or both of them before this is merged. It should be okay and merging it shouldn't require my permission. As soon as it is approved by one of the two above please commit the merge.

This PR simply adds data migrations adding the new field to events and transforming the old event date & time fields into a new single datetime field. This is to better align our model with our sister team. It should simplify things somewhat, and Professor Wade wishes it of us.

I made these changes while working on my deliverables (which I have not included in this PR), so please examine things closely and even check it by pulling the branch in order to ensure that things are working as expected. The anticipated behavior is that after running `rails db:migrate`, the PostgreSQL server should reflect Events having `start_time` and a new `participation_tracker_id` field which defaults to `null` I hope.