### PR TITLE
Dante/api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.1'
+ruby '>= 2.7.1'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.3', '>= 6.0.3.3'

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,9 @@ gem 'bootsnap', '>= 1.4.2', require: false
 
 gem 'rubocop', groups: %i[development test]
 
+gem 'whenever', require: false
+gem 'excon'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,11 +79,13 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    chronic (0.10.2)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     diff-lcs (1.4.4)
     docile (1.3.2)
     erubi (1.9.0)
+    excon (0.78.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.13.1)
@@ -268,6 +270,8 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.4.0)
@@ -281,6 +285,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
+  excon
   jbuilder (~> 2.7)
   omniauth-auth0 (~> 2.2)
   omniauth-rails_csrf_protection (~> 0.1)
@@ -299,6 +304,7 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webdrivers
   webpacker (~> 4.0)
+  whenever
 
 RUBY VERSION
    ruby 2.7.1p83

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -27,7 +27,10 @@ class EventsController < ApplicationController
   end
 
   def create
-    @event = Event.new(event_params)
+    ep = event_params
+    ep[:participation_tracker_id] = nil
+    puts ep
+    @event = Event.new(ep)
     if @event.save
       flash[:notice] = 'Event Created Successfully'
       redirect_to(events_path)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -5,15 +5,13 @@ class Event < ApplicationRecord
 
   has_and_belongs_to_many :members
   validates :name, presence: true
-  validates :date, presence: true
-  validates :time, presence: true
+  validates :start_time, presence: true
   validates :event_type, presence: true
   validates :attendance_points, numericality: true, presence: true
   enum event_type: { general: 0, mentorship: 10, socials: 20 }
 
   scope :filter_by_name, ->(name) { where('lower(name) LIKE :name', name: "%#{name.downcase}%") }
-  scope :filter_by_date, ->(date) { where(date: date) }
-  scope :filter_by_time, ->(time) { where(time: time) }
+  scope :filter_by_start_time, ->(start_time) { where(start_time: start_time) }
   scope :filter_by_hidden, ->(hidden) { where(hidden: hidden) }
   scope :filter_by_event_type, ->(event_type) { where(event_type: event_type) }
   scope :filter_by_attendance_points, ->(attendance_points) { where(attendance_points: attendance_points) }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,7 +8,6 @@ class Event < ApplicationRecord
   validates :start_time, presence: true
   validates :event_type, presence: true
   validates :attendance_points, numericality: true, presence: true
-  validates :participation_tracker_id, numericality: true
   enum event_type: { general: 0, mentorship: 10, socials: 20 }
 
   scope :filter_by_name, ->(name) { where('lower(name) LIKE :name', name: "%#{name.downcase}%") }

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -30,10 +30,6 @@
         <th>Attendance Points</th>
         <td><%= f.number_field(:attendance_points, in: 0.0..1000.0, step: 0.001) %></td>
       </tr>
-      <tr>
-        <th>Participation Tracker Id</th>
-        <td><%= f.number_field(:participation_tracker_id, step: 1) %></td>
-      </tr>
     </table>
 
     <div class="form-buttons">

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,31 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+env :PATH, ENV['PATH']
+
+set :output, "log/cron.log"
+
+every 1.minute do
+
+  rake 'sample:test'
+  rake 'participation_tracker:update_events'
+
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -27,5 +27,6 @@ every 1.minute do
 
   rake 'sample:test'
   rake 'participation_tracker:update_events'
+  rake 'participation_tracker:update_events_members'
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,93 +10,94 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_201_019_215_651) do
+ActiveRecord::Schema.define(version: 2020_11_03_193937) do
+
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'accomplishments', force: :cascade do |t|
-    t.text 'name'
-    t.text 'description'
-    t.decimal 'points', default: '0.0'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.boolean 'is_dues'
+  create_table "accomplishments", force: :cascade do |t|
+    t.text "name"
+    t.text "description"
+    t.decimal "points", default: "0.0"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.boolean "is_dues"
   end
 
-  create_table 'accomplishments_members', force: :cascade do |t|
-    t.bigint 'accomplishment_id'
-    t.bigint 'member_id'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.bigint 'semester_id'
-    t.index ['accomplishment_id'], name: 'index_accomplishments_members_on_accomplishment_id'
-    t.index ['member_id'], name: 'index_accomplishments_members_on_member_id'
-    t.index ['semester_id'], name: 'index_accomplishments_members_on_semester_id'
+  create_table "accomplishments_members", force: :cascade do |t|
+    t.bigint "accomplishment_id"
+    t.bigint "member_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "semester_id"
+    t.index ["accomplishment_id"], name: "index_accomplishments_members_on_accomplishment_id"
+    t.index ["member_id"], name: "index_accomplishments_members_on_member_id"
+    t.index ["semester_id"], name: "index_accomplishments_members_on_semester_id"
   end
 
-  create_table 'events', force: :cascade do |t|
-    t.text 'name'
-    t.date 'date', null: false
-    t.time 'time'
-    t.decimal 'attendance_points', default: '0.0'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.integer 'event_type'
-    t.boolean 'hidden'
+  create_table "events", force: :cascade do |t|
+    t.text "name"
+    t.decimal "attendance_points", default: "0.0"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "event_type"
+    t.boolean "hidden"
+    t.bigint "participation_tracker_id"
+    t.datetime "start_time", null: false
   end
 
-  create_table 'events_members', id: false, force: :cascade do |t|
-    t.bigint 'member_id'
-    t.bigint 'event_id'
-    t.index ['event_id'], name: 'index_events_members_on_event_id'
-    t.index ['member_id'], name: 'index_events_members_on_member_id'
+  create_table "events_members", id: false, force: :cascade do |t|
+    t.bigint "member_id"
+    t.bigint "event_id"
+    t.index ["event_id"], name: "index_events_members_on_event_id"
+    t.index ["member_id"], name: "index_events_members_on_member_id"
   end
 
-  create_table 'manual_points', force: :cascade do |t|
-    t.bigint 'member_id'
-    t.decimal 'points', default: '0.0'
-    t.text 'reason_message'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.integer 'reason'
-    t.bigint 'semester_id'
-    t.index ['member_id'], name: 'index_manual_points_on_member_id'
-    t.index ['semester_id'], name: 'index_manual_points_on_semester_id'
+  create_table "manual_points", force: :cascade do |t|
+    t.bigint "member_id"
+    t.decimal "points", default: "0.0"
+    t.text "reason_message"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "reason"
+    t.bigint "semester_id"
+    t.index ["member_id"], name: "index_manual_points_on_member_id"
+    t.index ["semester_id"], name: "index_manual_points_on_semester_id"
   end
 
-  create_table 'members', force: :cascade do |t|
-    t.text 'name'
-    t.text 'email', null: false
-    t.integer 'class_year'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.integer 'role'
-    t.text 'uid', null: false
-    t.index ['email'], name: 'index_members_on_email', unique: true
-    t.index ['uid'], name: 'index_members_on_uid', unique: true
+  create_table "members", force: :cascade do |t|
+    t.text "name"
+    t.text "email", null: false
+    t.integer "class_year"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "role"
+    t.text "uid", null: false
+    t.index ["email"], name: "index_members_on_email", unique: true
+    t.index ["uid"], name: "index_members_on_uid", unique: true
   end
 
-  create_table 'semesters', force: :cascade do |t|
-    t.text 'name'
-    t.daterange 'dates', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
+  create_table "semesters", force: :cascade do |t|
+    t.text "name"
+    t.daterange "dates", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table 'sessions', force: :cascade do |t|
-    t.string 'session_id', null: false
-    t.text 'data'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['session_id'], name: 'index_sessions_on_session_id', unique: true
-    t.index ['updated_at'], name: 'index_sessions_on_updated_at'
+  create_table "sessions", force: :cascade do |t|
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
+    t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
-  add_foreign_key 'accomplishments_members', 'accomplishments'
-  add_foreign_key 'accomplishments_members', 'members'
-  add_foreign_key 'accomplishments_members', 'semesters'
-  add_foreign_key 'events_members', 'events'
-  add_foreign_key 'events_members', 'members'
-  add_foreign_key 'manual_points', 'members'
-  add_foreign_key 'manual_points', 'semesters'
+  add_foreign_key "accomplishments_members", "accomplishments"
+  add_foreign_key "accomplishments_members", "members"
+  add_foreign_key "accomplishments_members", "semesters"
+  add_foreign_key "events_members", "events"
+  add_foreign_key "events_members", "members"
+  add_foreign_key "manual_points", "members"
+  add_foreign_key "manual_points", "semesters"
 end

--- a/lib/tasks/participation_tracker.rake
+++ b/lib/tasks/participation_tracker.rake
@@ -1,0 +1,39 @@
+
+
+namespace :participation_tracker do
+  def request_api(url)
+    response = Excon.get(
+      url#,
+      # headers: {
+      #   'X-RapidAPI-Host' => URI.parse(url).host,
+      #   'X-RapidAPI-Key' => ENV.fetch('RAPIDAPI_API_KEY')
+      # }
+    )
+    return nil if response.status != 200
+    JSON.parse(response.body)
+  end
+
+  desc "fetch and handle event list from bmes participation tracker"
+  task update_events: :environment do
+    events = Event.all
+    request_api('https://guarded-plateau-56846.herokuapp.com/api/v1/events')["events"].each do |pt_event|
+      event_exists = false
+      events.each do |event|
+        unless event.participation_tracker_id then
+          if event.start_time == pt_event["start_time"] then
+            puts "#{event.name} is the same as #{pt_event["name"]} based on the time. The shared id is: #{pt_event["id"]}"
+            event.update(participation_tracker_id: pt_event["id"])
+          end
+        end
+        if event.participation_tracker_id == pt_event["id"] then
+          event_exists = true
+          break
+        end
+      end
+      unless event_exists then
+        puts "#{pt_event["name"]} does not exist, so it is getting created. The shared id is: #{pt_event["id"]}"
+        Event.create(name: pt_event["name"], start_time: pt_event["start_time"], participation_tracker_id: pt_event["id"], event_type: 'general', hidden: false)
+      end
+    end
+  end
+end

--- a/lib/tasks/participation_tracker.rake
+++ b/lib/tasks/participation_tracker.rake
@@ -36,4 +36,21 @@ namespace :participation_tracker do
       end
     end
   end
+
+  desc "fetch the attendance data for each linked event"
+  task update_events_members: :environment do
+    events = Event.where.not(participation_tracker_id: nil)
+    events.each do |event|
+      attendees = request_api("https://guarded-plateau-56846.herokuapp.com/api/v1/event?id=#{event.participation_tracker_id}")["attendees"]
+      attendees.each do |attendee|
+        member = Member.find_by_email(attendee["email"])
+        if member then
+          puts "#{attendee["email"]} went to #{event.name}."
+          member.events << event
+        else
+          puts "#{attendee["email"]} is not owned by any account in the Member Point Tracker."
+        end
+      end
+    end
+  end
 end

--- a/lib/tasks/sample.rake
+++ b/lib/tasks/sample.rake
@@ -1,0 +1,9 @@
+namespace :sample do
+  desc "saying hi to cron"
+  task test: :environment do
+
+    puts Time.now
+
+  end
+
+end

--- a/spec/features/accomplishments_spec.rb
+++ b/spec/features/accomplishments_spec.rb
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
+
 # This spec tests to ensure accomplishments can be created and deleted
 require 'rails_helper'
 
-
 describe 'Accomplishments CRUD Features' do
   before :each do
-    user = {'name' => 'New Admin', 'email' => 'admin@user.com', 'uid' => 'user|3', 'kicked_out' => false}
+    user = { 'name' => 'New Admin', 'email' => 'admin@user.com', 'uid' => 'user|3', 'kicked_out' => false }
     page.set_rack_session(userinfo: user)
     page.set_rack_session(app_user: user)
 
@@ -32,10 +33,8 @@ describe 'Accomplishments CRUD Features' do
     fill_in 'accomplishment_points', with: '10.0'
     click_on('Create Accomplishment')
 
-
     click_on(class: 'fa fa-trash fa-lg')
     click_on('Delete Accomplishment')
     expect(page).to have_content 'Destroyed Successfully'
   end
-
 end

--- a/spec/features/events_spec.rb
+++ b/spec/features/events_spec.rb
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
+
 # This spec tests to ensure events can be created and deleted
 require 'rails_helper'
 
-
 describe 'Events CRUD Features' do
   before :each do
-    user = {'name' => 'New Admin', 'email' => 'admin@user.com', 'uid' => 'user|3', 'kicked_out' => false}
+    user = { 'name' => 'New Admin', 'email' => 'admin@user.com', 'uid' => 'user|3', 'kicked_out' => false }
     page.set_rack_session(userinfo: user)
     page.set_rack_session(app_user: user)
 
@@ -33,5 +34,4 @@ describe 'Events CRUD Features' do
     click_on('Delete Event')
     expect(page).to have_content 'Event Destroyed Successfully'
   end
-
 end

--- a/spec/features/manual_points_spec.rb
+++ b/spec/features/manual_points_spec.rb
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
+
 # This spec tests to ensure manual points can be created and deleted
 require 'rails_helper'
 
-
 describe 'Manual Points CRUD Features' do
   before :each do
-    user = {'name' => 'New Admin', 'email' => 'admin@user.com', 'uid' => 'user|3', 'kicked_out' => false}
+    user = { 'name' => 'New Admin', 'email' => 'admin@user.com', 'uid' => 'user|3', 'kicked_out' => false }
     page.set_rack_session(userinfo: user)
     page.set_rack_session(app_user: user)
 
@@ -34,5 +35,4 @@ describe 'Manual Points CRUD Features' do
     click_on('Delete Manual Points')
     expect(page).to have_content 'Points Manually Deleted Successfully'
   end
-
 end

--- a/spec/features/point_transfer_spec.rb
+++ b/spec/features/point_transfer_spec.rb
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
+
 # This spec tests to ensure semesters point transfers can occur
 require 'rails_helper'
 
-
 describe 'Semester Point Transfer Features' do
   before :each do
-    user = {'name' => 'New Admin', 'email' => 'admin@user.com', 'uid' => 'user|3', 'kicked_out' => false}
+    user = { 'name' => 'New Admin', 'email' => 'admin@user.com', 'uid' => 'user|3', 'kicked_out' => false }
     page.set_rack_session(userinfo: user)
     page.set_rack_session(app_user: user)
 
@@ -28,6 +29,4 @@ describe 'Semester Point Transfer Features' do
     click_on 'Undo Transfer Points Between Semester'
     expect(page).to have_content 'Delete Semester Transfer Points'
   end
-
-
 end

--- a/spec/features/profile_spec.rb
+++ b/spec/features/profile_spec.rb
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
+
 # This spec tests to ensure user profiles can be edited
 require 'rails_helper'
 
-
 describe 'Profile Edit Features' do
   before :each do
-    user = {'name' => 'New Admin', 'email' => 'admin@user.com', 'uid' => 'user|3', 'kicked_out' => false}
+    user = { 'name' => 'New Admin', 'email' => 'admin@user.com', 'uid' => 'user|3', 'kicked_out' => false }
     page.set_rack_session(userinfo: user)
     page.set_rack_session(app_user: user)
 
@@ -25,6 +26,4 @@ describe 'Profile Edit Features' do
     click_on 'Save Member'
     expect(page).to have_content 'NewName'
   end
-
-
 end

--- a/spec/features/semesters_spec.rb
+++ b/spec/features/semesters_spec.rb
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
+
 # This spec tests to ensure semesters can be created and deleted
 require 'rails_helper'
 
-
 describe 'Semester CRUD Features' do
   before :each do
-    user = {'name' => 'New Admin', 'email' => 'admin@user.com', 'uid' => 'user|3', 'kicked_out' => false}
+    user = { 'name' => 'New Admin', 'email' => 'admin@user.com', 'uid' => 'user|3', 'kicked_out' => false }
     page.set_rack_session(userinfo: user)
     page.set_rack_session(app_user: user)
 
@@ -16,7 +17,6 @@ describe 'Semester CRUD Features' do
 
     member.save
   end
-
 
   it 'Can access the Semesters page as admin' do
     visit '/semesters'
@@ -45,5 +45,4 @@ describe 'Semester CRUD Features' do
     click_on 'Delete Semester'
     expect(page).to have_content 'destroyed successfully.'
   end
-
 end


### PR DESCRIPTION
This code allows the Participation Tracker to send its information to the Member Point tracker through their API.

Joins:
`ParticipationTracker.Events` to `MemberPointTracker.Events` on `start_time`
`ParticipationTracker.Attendance` to `MemberPointTracker.Members` on `email`

The tasks are written using the `whenever` gem which *WILL NOT WORK* if the machine it runs on does not have `cron`. Heroku *does* have `cron`, but it is on a per-dyno level and running the requisite commands to prime `cron` works but when the dyno dies (reportedly as soon as the commands are done running) the `cron` jobs all stop. We can use the Heroku Scheduling Extension, which I've read a little about. I'll look into it more tomorrow after my ATMO Exam.