### PR TITLE
Permit newer ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.1'
+ruby '>= 2.7.1'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.3', '>= 6.0.3.3'


### PR DESCRIPTION
This is a trivial PR that permits using Ruby 2.7.2 which is the newer version. Things are still backwards-compatible with Ruby 2.7.1.